### PR TITLE
Add emulation of separate chats for whatsapp contact through empty groups

### DIFF
--- a/wat_bridge/helper.py
+++ b/wat_bridge/helper.py
@@ -38,7 +38,7 @@ def db_add_blacklist(phone):
     Returns:
         ID of the inserted element.
     """
-    return DB.insert({'name': None, 'phone': phone, 'blacklisted': True})
+    return DB.insert({'name': None, 'phone': phone, 'blacklisted': True, 'group': None})
 
 def db_add_contact(name, phone):
     """Add a new contact to the database.
@@ -50,7 +50,7 @@ def db_add_contact(name, phone):
     Returns:
         ID of the inserted element.
     """
-    return DB.insert({'name': name.lower(), 'phone': phone, 'blacklisted': False})
+    return DB.insert({'name': name.lower(), 'phone': phone, 'blacklisted': False, 'group': None})
 
 def db_list_contacts():
     """Obtain a list of contacts.
@@ -62,7 +62,7 @@ def db_list_contacts():
     """
     result = DB.search(CONTACT.blacklisted == False)
 
-    return [(a['name'], a['phone']) for a in result]
+    return [(a['name'], a['phone'], a.get('group')) for a in result]
 
 def db_rm_blacklist(phone):
     """Removes a blacklisted phone from the database.
@@ -140,3 +140,37 @@ def is_blacklisted(phone):
         return False
 
     return True
+
+def db_get_group(contact):
+    result = DB.get((CONTACT.name == contact.lower()))
+
+    if not result:
+        return None
+
+    # return None for backward compatibility if there is no group column
+    return result.get('group')
+
+def db_set_group(contact, group):
+    DB.update({'group': group}, (CONTACT.name == contact.lower()))
+
+def db_get_contact_by_group(group):
+    """Get phone number from a group id.
+
+    Args:
+        group (int): Group id assigned to the contact.
+
+    Returns:
+        String with the phone number or `None` if not found.
+    """
+    result = DB.get((CONTACT.group == group))
+
+    if not result:
+        return None
+
+    return result['name']
+
+def safe_cast(val, to_type, default=None):
+    try:
+        return to_type(val)
+    except (ValueError, TypeError):
+        return default

--- a/wat_bridge/static.py
+++ b/wat_bridge/static.py
@@ -66,7 +66,7 @@ def get_logger(name):
 
 def init_bridge():
     """Parse the configuration file and set relevant variables."""
-    conf_path = os.getenv('WAT_CONF', '')
+    conf_path = os.path.abspath(os.getenv('WAT_CONF', ''))
 
     if not conf_path or not os.path.isfile(conf_path):
         sys.exit('Could not find configuration file')

--- a/wat_bridge/tg.py
+++ b/wat_bridge/tg.py
@@ -114,8 +114,8 @@ def add_contact(message):
     tgbot.reply_to(message, 'Contact added')
 
 @tgbot.message_handler(commands=['bind'])
-def add_contact(message):
-    """Add a new Whatsapp contact to the database.
+def bind(message):
+    """Bind a contact to a group.
 
     Message has the following format:
 
@@ -158,8 +158,8 @@ def add_contact(message):
     tgbot.reply_to(message, 'Bound to group')
 
 @tgbot.message_handler(commands=['unbind'])
-def add_contact(message):
-    """Add a new Whatsapp contact to the database.
+def unbind(message):
+    """Unbind a contact from his group.
 
     Message has the following format:
 
@@ -356,8 +356,12 @@ def unblacklist(message):
     tgbot.reply_to(message, 'Phone has been unblacklisted')
 
 @tgbot.message_handler(func=lambda message: message.chat.type in ['group', 'supergroup'])
-def handle_channel(message):
+def relay_group_wa(message):
+    """ Send a message received in a bound group to the correspondending contact through Whatsapp.
 
+    Args:
+        message: Received Telegram message.
+    """
     cid = message.chat.id
     uid = message.from_user.id
 


### PR DESCRIPTION
A whatsapp contact can be bound to a group containing the bot. Now each message send in this group will be relayed to the whatsapp contact. And each message sent by the conact will be posted into the group.